### PR TITLE
16章 1+N問題解決

### DIFF
--- a/app/controllers/admin/customers_controller.rb
+++ b/app/controllers/admin/customers_controller.rb
@@ -3,7 +3,7 @@ class Admin::CustomersController < ApplicationController
   before_action :set_customer, only: %i[show update]
 
   def index
-    @customers = Customer.latest
+    @customers = Customer.preload(:orders).latest
   end
 
   def show; end

--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -13,8 +13,8 @@ class Admin::PagesController < ApplicationController
 
   def get_orders(params)
     if !params[:status].present? || !Order.statuses.keys.to_a.include?(params[:status])
-      return [Order.latest,
-              'all']
+      # 「customer」と単数形なのは、customers テーブルが orders テーブルから見て親だから
+      return [Order.eager_load(:customer).latest, 'all']
     end
 
     get_by_enum_value(params[:status])


### PR DESCRIPTION
## やったこと
以下の画面で発生している1+N問題の解決

- 注文履歴一覧画面
  - orders テーブルから全レコードを取得した後、order のレコード一件につき、customers テーブルへの SQL 文が発行されていた（ビューで order を一件一件表示する際に、顧客のメールアドレスを取得しているため）
    - `eager_load`を使って解決
- 顧客一覧画面
  - customers テーブルから全レコードを取得した後、customer のレコード一件につき、orders テーブルへの SQL 文が発行されていた（ビューで customer を一件一件表示する際に、その customer の注文数を取得しているため）
    - `preload`を使って解決

## 参考
https://zenn.dev/farstep/books/7f169cdc597ada/viewer/e62774